### PR TITLE
Adjust line and column number in stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DESCRIPTION
 ---------------------------------------
 `espower-loader` is a Node.js module loader that enhances target sources on the fly. So you can instrument Power Assert feature without code generation for now.
 
-`espower-loader` applies [espower](http://github.com/twada/espower) to target sources on loading them. `espower` manipulates assertion expression (JavaScript Code) represented as [Mozilla JavaScript AST](https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API), to instrument power-assert feature into the code.
+`espower-loader` applies [espower](http://github.com/twada/espower) to target sources on loading them. `espower` manipulates assertion expression (JavaScript Code) represented as [Mozilla JavaScript AST](https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API), to instrument power-assert feature into the code. `espower-loader` also adjusts line and column number in stack traces by using [node-source-map-support](https://github.com/evanw/node-source-map-support) module.
 
 Please note that `espower-loader` is a beta version product. Pull-requests, issue reports and patches are always welcomed. See [power-assert](http://github.com/twada/power-assert) project for more documentation.
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "url": "https://github.com/twada/espower-loader/issues"
   },
   "dependencies": {
+    "convert-source-map": "~1.1.0",
     "espower-source": "~0.10.0",
-    "minimatch": "~2.0.4"
+    "minimatch": "~2.0.4",
+    "source-map-support": "~0.2.10"
   },
   "devDependencies": {
     "empower": "~0.11.0",

--- a/test/tobe_instrumented/tobe_instrumented_test.js
+++ b/test/tobe_instrumented/tobe_instrumented_test.js
@@ -5,13 +5,15 @@ var empower = require('empower'),
 
 describe('power-assert message', function () {
     beforeEach(function () {
-        this.expectPowerAssertMessage = function (body, expectedLines) {
+        this.expectPowerAssertMessage = function (body, expectedLines, expectedPosition) {
             try {
                 body();
             } catch (e) {
                 expect(e.message.split('\n').slice(2, -1)).to.eql(expectedLines.map(function (line) {
                     return line;
                 }));
+                var re = new RegExp("test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedPosition + "\n");
+                expect(e.stack).to.match(re);
                 return;
             }
             expect().fail("AssertionError should be thrown");
@@ -34,7 +36,7 @@ describe('power-assert message', function () {
             '  => 3',
             '  [number] three * (seven * ten)',
             '  => 210'
-        ]);
+        ], '26:13');
     });
 
     it('equal with Literal and Identifier: assert.equal(1, minusOne);', function () {
@@ -45,7 +47,7 @@ describe('power-assert message', function () {
             '  assert.equal(1, minusOne)',
             '                  |        ',
             '                  -1       '
-        ]);
+        ], '45:20');
     });
 
 });


### PR DESCRIPTION
Adjust line and column number in stack traces by using [source-map-support](https://github.com/evanw/node-source-map-support) module.

- [x] deps
- [x] test
- [x] implement
- [x] document
